### PR TITLE
Add fallthrough statements to switch statements

### DIFF
--- a/3rdparty/headers/SDL_stdinc.h
+++ b/3rdparty/headers/SDL_stdinc.h
@@ -449,10 +449,10 @@ SDL_FORCE_INLINE void SDL_memset4(void *dst, Uint32 val, size_t dwords)
         return;
     switch (dwords % 4)
     {
-        case 0: do {    *_p++ = _val;   /* fallthrough */
-        case 3:         *_p++ = _val;   /* fallthrough */
-        case 2:         *_p++ = _val;   /* fallthrough */
-        case 1:         *_p++ = _val;   /* fallthrough */
+        case 0: do {    *_p++ = _val; [[fallthrough]];   /* fallthrough */
+        case 3:         *_p++ = _val; [[fallthrough]];   /* fallthrough */
+        case 2:         *_p++ = _val; [[fallthrough]];   /* fallthrough */
+        case 1:         *_p++ = _val; [[fallthrough]];   /* fallthrough */
         } while ( --_n );
     }
 #endif

--- a/3rdparty/headers/SDL_stdinc.h
+++ b/3rdparty/headers/SDL_stdinc.h
@@ -452,7 +452,7 @@ SDL_FORCE_INLINE void SDL_memset4(void *dst, Uint32 val, size_t dwords)
         case 0: do {    *_p++ = _val; [[fallthrough]];   /* fallthrough */
         case 3:         *_p++ = _val; [[fallthrough]];   /* fallthrough */
         case 2:         *_p++ = _val; [[fallthrough]];   /* fallthrough */
-        case 1:         *_p++ = _val; [[fallthrough]];   /* fallthrough */
+        case 1:         *_p++ = _val;                    /* fallthrough */
         } while ( --_n );
     }
 #endif


### PR DESCRIPTION
SDL_stdinc.h contains a case/switch that utlitizes fallthroughs, and the proper `[[fallthrough]]` declarations have been added.

Resolves #3.