### PR TITLE
Correct header paths.

### DIFF
--- a/cube.h
+++ b/cube.h
@@ -43,8 +43,8 @@
     #define ZLIB_DLL
 #endif
 
-#include <SDL.h>
-#include <SDL_opengl.h>
+#include "3rdparty/headers/SDL.h"
+#include "3rdparty/headers/SDL_opengl.h"
 
 #include <zlib.h>
 


### PR DESCRIPTION
Correct the header path by using the current path instead of the default
path, since using the default path assumes the user has already
installed the header.
