### PR TITLE
Add header guards and use Doxygen documentation tags.

### DIFF
--- a/command.h
+++ b/command.h
@@ -1,4 +1,10 @@
-// script binding functionality
+/**
+ * @file command.h
+ * @brief Script binding functionality.
+ */
+
+#ifndef COMMAND_H_
+#define COMMAND_H_
 
 enum
 {
@@ -777,3 +783,5 @@ inline void ident::getcval(tagval &v) const
 #define ICOMMANDNS(name, cmdname, nargs, proto, b) ICOMMANDKNS(name, Id_Command, cmdname, nargs, proto, b)
 #define ICOMMANDN(name, cmdname, nargs, proto, b) ICOMMANDNS(#name, cmdname, nargs, proto, b)
 #define ICOMMAND(name, nargs, proto, b) ICOMMANDN(name, ICOMMANDNAME(name), nargs, proto, b)
+
+#endif /* COMMAND_H_ */

--- a/consts.h
+++ b/consts.h
@@ -1,23 +1,19 @@
+/**
+ * @file consts.h
+ * @brief Useful egnine constants.
+ *
+ * This is a header filled with constants that are useful to pass appropriate
+ * information from the game to the engine; howerver, it is only for those
+ * constants which are directly useful for the engine-game interface and not for
+ * constants which solely lie in the engine or game.
+ */
+
 #ifndef CONSTS_H_
 #define CONSTS_H_
-/* consts.h
- *
- * This is a header filled with constants that are useful to pass appropriate information
- * from the game to the engine; it is only for those constants which are directly useful for
- * the engine-game interface and not for constants which solely lie in the engine or game
- */
 
 #define IS_LIQUID(mat) ((mat)==Mat_Water)
 #define IS_CLIPPED(mat) ((mat)==Mat_Glass) //materials that are obligate clipping (always also get clipped)
 #define LOOP_START(id, stack) if((id)->type != Id_Alias) return; identstack stack;
-
-
-enum                            // hardcoded texture numbers
-{
-    Default_Sky = 0,
-    Default_Geom,
-    Default_NumDefaults
-};
 
 enum
 {
@@ -237,4 +233,4 @@ enum
     Init_Reset,
 };
 
-#endif
+#endif /* CONSTS_H_ */

--- a/cube.h
+++ b/cube.h
@@ -1,3 +1,11 @@
+/**
+ * @file cube.h
+ * @brief Needed for making games, along with iengine.h and consts.h.
+ *
+ * This header file, along with iengine.h and consts.h should be included when
+ * making games.
+ */
+
 #ifndef CUBE_H_
 #define CUBE_H_
 
@@ -52,12 +60,13 @@
 #include "geom.h"
 #include "ents.h"
 #include "command.h"
+#include "world.h"
 #include "octa.h"
-#include "slot.h"
 
 #include "glexts.h"
 #include "glemu.h"
 
 #include "consts.h"
-#endif
+
+#endif /* CUBE_H_ */
 

--- a/ents.h
+++ b/ents.h
@@ -1,7 +1,16 @@
-// this file defines static map entities ("entity") and dynamic entities (players/monsters, "dynent")
-// the gamecode extends these types to add game specific functionality
+/**
+ * @file ents.h
+ * @brief Static map entities and dynamic entities.
+ *
+ * The file defines static map entities of type "entity" and dynamic entities of
+ * type "dynent" like players or monsters. The gamecode extends these types to
+ * add game specific functionality. Note that enties with the infix "Ent_" are
+ * the only static entity types dictated by the engine. The rest are gamecode
+ * dependent.
+ */
 
-// Ent_*: the only static entity types dictated by the engine... rest are gamecode dependent
+#ifndef ENTS_H_
+#define ENTS_H_
 
 enum
 {
@@ -285,3 +294,5 @@ struct dynent : physent                         // animated characters, or chara
         return vec(o).addz(aboveeye+4);
     }
 };
+
+#endif /* ENTS_H_ */

--- a/geom.h
+++ b/geom.h
@@ -1,3 +1,11 @@
+/**
+ * @file geom.h
+ * @brief 
+ */
+
+#ifndef GEOM_H_
+#define GEOM_H_
+
 struct vec;
 struct vec4;
 
@@ -2368,3 +2376,4 @@ inline float sin360(int angle) { return sincos360[angle].y; }
 inline float tan360(int angle) { const vec2 &sc = sincos360[angle]; return sc.y/sc.x; }
 inline float cotan360(int angle) { const vec2 &sc = sincos360[angle]; return sc.x/sc.y; }
 
+#endif /* GEOM_H_ */

--- a/glemu.h
+++ b/glemu.h
@@ -1,3 +1,11 @@
+/**
+ * @file glemu.h
+ * @brief 
+ */
+
+#ifndef GLEMU_H_
+#define GLEMU_H_
+
 namespace gle
 {
     enum
@@ -178,3 +186,4 @@ namespace gle
     extern void cleanup();
 }
 
+#endif /* GLEMU_H_ */

--- a/glexts.h
+++ b/glexts.h
@@ -1,3 +1,11 @@
+/**
+ * @file glexts.h
+ * @brief 
+ */
+
+#ifndef GLEXTS_H_
+#define GLEXTS_H_
+
 #ifndef APIENTRY
 #define APIENTRY
 #endif
@@ -726,3 +734,4 @@ extern PFNGLGETDEBUGMESSAGELOGPROC glGetDebugMessageLog_;
 // GL_ARB_copy_image
 extern PFNGLCOPYIMAGESUBDATAPROC glCopyImageSubData_;
 
+#endif /* GLEXTS_H_ */

--- a/iengine.h
+++ b/iengine.h
@@ -1,10 +1,14 @@
-/* iengine.h
+/**
+ * @file iengine.h
+ * @brief The interface the game uses to access the engine.
  *
- * the interface the game uses to access the engine
- * this file contains those functions which comprise the API with which to write
- * a game against; this header is not called by the game internally and is the
- * header which should be included in the game code.
+ * The file contains functions which comprise the API for writing games. This
+ * header file is not called by the game internally but should be included in
+ * the game code to expose functions to the game.
  */
+
+#ifndef IENGINE_H_
+#define IENGINE_H_
 
 extern uint totalsecs;
 extern int gamespeed, paused;
@@ -30,40 +34,47 @@ struct prefab;
 
 // ragdoll
 
-/**
- * moveragdoll: update a ragdoll's physics
- *
- * moveragdoll takes a dynent pointer as an argument and updates its position & physics
- * if the dynent pointed to does not have a valid ragdoll object as a member,
- * nothing happens
- */
+ /**
+  * @brief Update a ragdoll's position and physics.
+  *
+  * If the dynent pointed to does not have a valid ragdoll object as a member,
+  * nothing happens.
+  * @param d a dynent pointer.
+  */
 extern void moveragdoll(dynent *d);
 
 /**
- * cleanragdoll: deletes the ragdoll associated with the passed dynent
+ * @brief Deletes the ragdoll associated with the passed dynent.
  *
- * cleanragdoll takes a dynent pointer as an argument and removes the ragdoll
- * if present
- * if the dynent pointed to is not a ragdoll (no ragdoll object), nothing happens
+ * The function does nothinf if the dynent does not point to a ragdoll object.
+ * Also, the function does nothing if the dynent is a ragdoll that is not
+ * present.
+ * @param d a dynent pointer.
  */
 extern void cleanragdoll(dynent *d);
 
 // crypto
 
 /**
- * genprivkey: given a seed value, creates a priv/pub key pair
+ * @brief Creates a private-public key pair from a given seed value.
  *
- * given a pair of references to the desired priv/pub key locations, and a seed,
- * genprivkey() returns (in the form of changing the two references passed as arguments)
- * a matching private/public key pair
+ * The function takes a reference to the desired private and public keys, and
+ * then modifies the contents of both strings using the seed. The modified
+ * strings are the matching private-public key pair.
+ * @param seed The seed value for generating random private-public key pairs.
+ * @param privstr The private string to modify.
+ * @param pubstr The public string to modify.
  */
 extern void genprivkey(const char *seed, vector<char> &privstr, vector<char> &pubstr);
 
 /**
- * calcpubkey: verify a public key against a private key
+ * @brief Verify a public key against a private key.
  *
- * given a public key and private key, verify that the two keys make a matching pair
- * returns true if the keys match, false otherwise
+ * Verify that the given public key and the given private key make a matching pair.
+ * @param privstr The private key that was generated as part of a private-public key pair.
+ * @param pubstr The public key that was generated as part of a private-public key pair.
+ * @return true If the strings match and make a private-public key pair.
+ * @return false If the strings do not match and do not make a private-public key pair.
  */
 extern bool calcpubkey(const char *privstr, vector<char> &pubstr);
 extern bool hashstring(const char *str, char *result, int maxlen);
@@ -146,7 +157,6 @@ extern dynent *player;
 extern bool inbetweenframes,
             renderedframe;
 
-extern bool initsdl();
 extern void fatal(const char *s, ...) PRINTFARGS(1, 2);
 extern int getclockmillis();
 extern int initing;
@@ -543,7 +553,7 @@ extern ushort getmaterial(cube &c);
 
 extern int octaentsize;
 
-extern bool emptymap(int factor, bool force, bool usecfg = true);
+extern bool emptymap(int factor, bool force, const char *mname = "", bool usecfg = true);
 extern bool enlargemap(bool force);
 extern vec getselpos();
 extern int getworldsize();
@@ -579,3 +589,4 @@ extern uint getmapcrc();
 extern void clearmapcrc();
 extern bool loadents(const char *fname, const char *gameident, vector<entity> &ents, uint *crc = nullptr);
 
+#endif /* IENGINE_H_ */

--- a/octa.h
+++ b/octa.h
@@ -1,3 +1,11 @@
+/**
+ * @file octa.h
+ * @brief 
+ */
+
+#ifndef OCTA_H_
+#define OCTA_H_
+
 // 6-directional octree heightfield map format
 
 struct elementset
@@ -12,6 +20,15 @@ struct elementset
         ushort reuse;
     };
     ushort length, minvert, maxvert;
+};
+
+struct materialsurface
+{
+    ivec o;
+    ushort csize, rsize;
+    ushort material, skip;
+    uchar orient, visible;
+    uchar ends;
 };
 
 struct vertinfo
@@ -607,3 +624,5 @@ struct undolist
         return u;
     }
 };
+
+#endif /* OCTA_H_ */

--- a/slot.h
+++ b/slot.h
@@ -1,3 +1,11 @@
+/**
+ * @file slot.h
+ * @brief 
+ */
+
+#ifndef SLOT_H_
+#define SLOT_H_
+
 enum
 {
     VSlot_ShParam = 0,
@@ -240,3 +248,5 @@ extern Slot &lookupslot(int slot, bool load = true);
 extern VSlot &lookupvslot(int slot, bool load = true);
 extern bool unpackvslot(ucharbuf &buf, VSlot &dst, bool delta);
 extern DecalSlot &lookupdecalslot(int slot, bool load = true);
+
+#endif /* SLOT_H_ */

--- a/tools.h
+++ b/tools.h
@@ -1,4 +1,7 @@
-// generic useful stuff for any C++ program
+/**
+ * @file tools.h
+ * @brief Generic and useful functions, constants, macros, etc., for any C++ program.
+ */
 
 #ifndef TOOLS_H_
 #define TOOLS_H_
@@ -1635,5 +1638,4 @@ extern void filtertext(char *dst, const char *src, bool whitespace, bool forcesp
 template<size_t N>
 inline void filtertext(char (&dst)[N], const char *src, bool whitespace = true, bool forcespace = false) { filtertext(dst, src, whitespace, forcespace, N-1); }
 
-#endif
-
+#endif /* TOOLS_H_ */


### PR DESCRIPTION
The header guards should help prevent re-definition problems.

Also, the existing comments on files and functions were modified to use
Doxygen tags for automatic documentation generation.

Some files still need a brief description:
  - geom.h
  - glemu.h
  - glexts.h
  - octa.h
  - slot.h
  - tools.h