### PR TITLE
Add default parameter and improve comments.

### DIFF
--- a/command.h
+++ b/command.h
@@ -380,10 +380,10 @@ extern void setsvar(const char *name, const char *str, bool dofunc = true);
  *
  * @param name of the command in Cubescript
  * @param fun a function pointer to be called when the command is executed
- * @param a string containing the arguments of the function
+ * @param narg string containing the arguments of the function
  * @param type the type of the command to create
  */
-extern bool addcommand(const char *name, identfun fun, const char *narg, int type = Id_Command);
+extern bool addcommand(const char *name, identfun fun, const char *narg = "", int type = Id_Command);
 
 extern std::queue<ident *> triggerqueue; /**< A queue of game events for the engine to process */
 

--- a/ents.h
+++ b/ents.h
@@ -138,6 +138,9 @@ struct physent
 
     int inwater;
     bool jumping;
+
+    // The velocity type: `move` is movement along camera axis while `strafe` is
+    // side-to-side movement perpendicular to camera axis.
     char move, strafe, crouching;
 
     uchar physstate;                            /**< one of PHYS_* above */


### PR DESCRIPTION
The default parameter makes the code more concise when commands do not
take any arguments.

Also, I fixed a typo on the `addcommand` docstring and added comments to
the `move`, `strafe`, and `crouching` variables. These comments should help make
the code less cryptic.