### PR TITLE
more `std::hash` and `operator==` overloads

### DIFF
--- a/geom.h
+++ b/geom.h
@@ -1750,16 +1750,6 @@ struct ivec
 
 inline vec::vec(const ivec &v) : x(v.x), y(v.y), z(v.z) {}
 
-inline bool htcmp(const ivec &x, const ivec &y)
-{
-    return x == y;
-}
-
-inline uint hthash(const ivec &k)
-{
-    return k.x^k.y^k.z;
-}
-
 template<>
 struct std::hash<ivec> {
     size_t operator()(const ivec &k) const {

--- a/geom.h
+++ b/geom.h
@@ -1750,6 +1750,16 @@ struct ivec
 
 inline vec::vec(const ivec &v) : x(v.x), y(v.y), z(v.z) {}
 
+inline bool htcmp(const ivec &x, const ivec &y)
+{
+    return x == y;
+}
+
+inline uint hthash(const ivec &k)
+{
+    return k.x^k.y^k.z;
+}
+
 template<>
 struct std::hash<ivec> {
     size_t operator()(const ivec &k) const {

--- a/octa.h
+++ b/octa.h
@@ -288,8 +288,6 @@ class cube
 
         //need htcmp to be free functions to work with tools.h
         //but nothing else needs it
-        friend bool htcmp(const cube::cfkey &x, const cube::cfkey &y);
-        friend uint hthash(const cube::cfkey &k);
         friend std::hash<plink>; //for unordered_map
         friend std::hash<cfkey>; //for unordered_map
 };

--- a/octa.h
+++ b/octa.h
@@ -286,6 +286,10 @@ class cube
             }
         };
 
+        //need htcmp to be free functions to work with tools.h
+        //but nothing else needs it
+        friend bool htcmp(const cube::cfkey &x, const cube::cfkey &y);
+        friend uint hthash(const cube::cfkey &k);
         friend std::hash<plink>; //for unordered_map
         friend std::hash<cfkey>; //for unordered_map
 };

--- a/octa.h
+++ b/octa.h
@@ -280,6 +280,10 @@ class cube
             ushort material, tex;
             ivec n;
             int offset;
+
+            bool operator==(const cfkey &o) {
+                    return orient == o.orient && tex == o.tex && n == o.n && offset == o.offset && material == o.material;
+            }
         };
 
         //need htcmp to be free functions to work with tools.h
@@ -287,6 +291,14 @@ class cube
         friend bool htcmp(const cube::cfkey &x, const cube::cfkey &y);
         friend uint hthash(const cube::cfkey &k);
         friend std::hash<plink>; //for unordered_map
+        friend std::hash<cfkey>; //for unordered_map
+};
+
+template<>
+struct std::hash<cube::cfkey> {
+    size_t operator()(const cube::cfkey &k) const {
+        return hthash(k.n)^k.offset^k.tex^k.orient^k.material;
+    }
 };
 
 /**

--- a/octa.h
+++ b/octa.h
@@ -286,8 +286,6 @@ class cube
             }
         };
 
-        //need htcmp to be free functions to work with tools.h
-        //but nothing else needs it
         friend std::hash<plink>; //for unordered_map
         friend std::hash<cfkey>; //for unordered_map
 };

--- a/octa.h
+++ b/octa.h
@@ -297,7 +297,7 @@ class cube
 template<>
 struct std::hash<cube::cfkey> {
     size_t operator()(const cube::cfkey &k) const {
-        return hthash(k.n)^k.offset^k.tex^k.orient^k.material;
+        return std::hash<ivec>{}(k.n)^k.offset^k.tex^k.orient^k.material;
     }
 };
 


### PR DESCRIPTION
added `std::hash<cube::cfkey>`, `operator==(const cube::cfkey&)`